### PR TITLE
Patched to work with Ring keyword params and clarified README. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple CAS client for Clojure, for use as a middleware with Ring.
 To install, add this to your project.clj:
 
 ```clojure
-  :dependencies [[clj-cas-client "0.0.5"]]
+  :dependencies [[clj-cas-client "0.0.6"]]
 ```
 
 To wrap a handler with cas:
@@ -25,7 +25,10 @@ To wrap a handler with cas:
 
 (def app (-> routes
              handler/site
-             (cas cas-server service-name)))
+             (cas cas-server service-name)
+	     wrap-keyword-params
+	     wrap-params
+	     wrap-session))
 ```
 
 This will redirect all requests to the cas server for login, validate the tickets from the cas server, and make sure to add a :username key to the request map.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-cas-client "0.0.5"
+(defproject clj-cas-client "0.0.6"
   :description "Makes it possible to wrap a Cas Client middleware around Ring handlers"
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/tools.logging "0.2.3"]

--- a/src/clj_cas_client/core.clj
+++ b/src/clj_cas_client/core.clj
@@ -19,7 +19,7 @@
 
 (defn- valid? [request]
   (or (get-in request [:session const-cas-assertion])
-      (get-in request [:params artifact-parameter-name])))
+      (get-in request [:query-params artifact-parameter-name])))
 
 (defn authentication-filter
   [handler cas-server-fn service-fn]
@@ -34,7 +34,7 @@
 (defn request-assertion [req assertion]
   (update-in req [:params] assoc const-cas-assertion assertion))
 
-(defn ticket [r] (get-in r [:params artifact-parameter-name]))
+(defn ticket [r] (get-in r [:query-params artifact-parameter-name]))
 
 (defn ticket-validation-filter-maker [validator-maker]
   (fn [handler cas-server-fn service-fn]

--- a/test/clj_cas_client/core_test.clj
+++ b/test/clj_cas_client/core_test.clj
@@ -1,3 +1,4 @@
+
 (ns clj-cas-client.core-test
   (:use clj-cas-client.core
         clojure.test)
@@ -16,10 +17,10 @@
 (deftest authentication-filter-test
   (let [af (authentication-filter (fn [r] [:test-authentication-filter r]) (fn [] "cas server fn") (fn [] "service fn"))]
     (is (= (af {:session {"_const_cas_assertion_" "blarg"}}) [:test-authentication-filter {:session {"_const_cas_assertion_" "blarg"}}]))
-    (is (= (af {:params {"ticket" "the tick"}}) [:test-authentication-filter {:params {"ticket" "the tick"}}]))
+    (is (= (af {:query-params {"ticket" "the tick"}}) [:test-authentication-filter {:query-params {"ticket" "the tick"}}]))
     (is (= (af {:session {"_const_cas_assertion_" "blarg"}
-                :params {"ticket" "the tick"}}) [:test-authentication-filter {:session {"_const_cas_assertion_" "blarg"}
-                                                                              :params {"ticket" "the tick"}}]))
+                :query-params {"ticket" "the tick"}}) [:test-authentication-filter {:session {"_const_cas_assertion_" "blarg"}
+                                                                              :query-params {"ticket" "the tick"}}]))
     (is (= (af {}) {:status 302 :headers {"Location" "cas server fn/login?service=service fn"}  :body ""}))))
 
 (def ^:dynamic test-validator (fn [cas-server-fn ticket service] nil))
@@ -39,12 +40,12 @@
                                (is (= ticket "ticket"))
                                (is (= service "service fn"))
                                :assertion)]
-      (is (= (tf {:params {"ticket" "ticket"}})
-             {:res [:test-ticket-validation-filter {:params {"ticket" "ticket"
-                                                             "_const_cas_assertion_" :assertion}}] :session {"_const_cas_assertion_" :assertion}})))
+      (is (= (tf {:query-params {"ticket" "ticket"}})
+             {:res [:test-ticket-validation-filter {:query-params {"ticket" "ticket"}
+                                                    :params {"_const_cas_assertion_" :assertion}}] :session {"_const_cas_assertion_" :assertion}})))
 
     (binding [test-validator (fn [cas-server-fn ticket service] (throw (TicketValidationException. "blah")))]
-      (is (= (tf {:params {"ticket" "ticket"}})
+      (is (= (tf {:query-params {"ticket" "ticket"}})
              {:status 403})))))
 
 (deftest user-principal-filter-test


### PR DESCRIPTION
Using query-params map for ticket parameter instead of params map. This works with Ring keyword-params middleware because *-params maps are not altered.

Clarified README to reflect implicit dependencies to Ring param and session middlewares which are required but not declared as dependencies.
