### PR TITLE
Make middleware dependencies explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To wrap a handler with cas:
 
 ```clojure
 (use 'clj-cas-client.core)
+(require '[ring.middleware.session :refer [wrap-session]])
 
 (defn cas-server []
   "https://example.org/cas")
@@ -25,8 +26,11 @@ To wrap a handler with cas:
 
 (def app (-> routes
              handler/site
-             (cas cas-server service-name)))
+             (cas cas-server service-name)
+             wrap-session))
 ```
+
+Note that clj-cas-client depends on the session middleware, so the handler returned by `cas` must be wrapped with `wrap-session`.
 
 This will redirect all requests to the cas server for login, validate the tickets from the cas server, and make sure to add a :username key to the request map.
 

--- a/src/clj_cas_client/core.clj
+++ b/src/clj_cas_client/core.clj
@@ -1,7 +1,8 @@
 
 (ns clj-cas-client.core
   (:use ring.util.response)
-  (:require [clojure.tools.logging :as log])
+  (:require [clojure.tools.logging :as log]
+            [ring.middleware.params :refer [wrap-params]])
   (:import (org.jasig.cas.client.validation Cas10TicketValidator
                                             TicketValidationException)))
 (def artifact-parameter-name "ticket")
@@ -66,5 +67,5 @@
           user-principal-filter
           (authentication-filter cas-server-fn service-fn)
           (ticket-validation-filter cas-server-fn service-fn)
-          )
+          wrap-params)
       handler)))


### PR DESCRIPTION
clj-cas-client depends on both the params and session middlewares. The
params middleware is idempotent, so there's no harm in adding it
ourselves. The session middleware must only be added once, so document
the dependency in README.
