### PR TITLE
Return 403 instead of redirect for requests matching predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,39 @@ Note that clj-cas-client depends on the session middleware, so the handler retur
 
 This will redirect all requests to the cas server for login, validate the tickets from the cas server, and make sure to add a :username key to the request map.
 
+## AJAX Requests
+
+By default `clj-cas-client` redirects unauthenticated users to the CAS server for authentication. This works fine with regular page loads, but causes problems with AJAX requests because `XMLHttpRequest` automatically follows all redirects, thus trying to retrieve the CAS server's login page as the response to the request (and typically failing due to the same-origin policy).
+
+To solve this problem, you can configure `clj-cas-client` to return `403 Forbidden` instead of `302 Found` in response to requests that match a given predicate. Just pass the predicate to the `cas` function as the `:no-redirect?` option. Then, in your JavaScript, check the response code of each AJAX response and reload the page on a `403`.
+
+If there's no other way to detect AJAX requests (e.g. by their URL), you can add a custom HTTP header to them and check for it in your predicate:
+
+```javascript
+$.ajax({
+  url: "/my/api",
+  headers: {"my-ajax-request-header": true},
+  statusCode: {
+    403: function(){
+      location.reload(true);
+    }
+  },
+  success: function(data){
+    // do something with data
+  }
+})
+```
+
+```clojure
+(defn ajax-request? [request]
+  (get-in request [:headers "my-ajax-request-header"]))
+
+(def app (-> routes
+             handler/site
+             (cas cas-server service-name :no-redirect? ajax-request?)
+             wrap-session))
+```
+
 ## Single Sign Out
 
 For single sign out, use the [cas-single-sign-out](https://github.com/solita/cas-single-sign-out) middleware.

--- a/test/clj_cas_client/core_test.clj
+++ b/test/clj_cas_client/core_test.clj
@@ -14,13 +14,15 @@
     (is (instance? Cas10TicketValidator v))))
 
 (deftest authentication-filter-test
-  (let [af (authentication-filter (fn [r] [:test-authentication-filter r]) (fn [] "cas server fn") (fn [] "service fn"))]
+  (let [af (authentication-filter (fn [r] [:test-authentication-filter r]) (fn [] "cas server fn") (fn [] "service fn")
+                                  (fn [r] (get-in r [:headers "ajax-request"])))]
     (is (= (af {:session {"_const_cas_assertion_" "blarg"}}) [:test-authentication-filter {:session {"_const_cas_assertion_" "blarg"}}]))
     (is (= (af {:query-params {"ticket" "the tick"}}) [:test-authentication-filter {:query-params {"ticket" "the tick"}}]))
     (is (= (af {:session {"_const_cas_assertion_" "blarg"}
                 :query-params {"ticket" "the tick"}}) [:test-authentication-filter {:session {"_const_cas_assertion_" "blarg"}
                                                                               :query-params {"ticket" "the tick"}}]))
-    (is (= (af {}) {:status 302 :headers {"Location" "cas server fn/login?service=service fn"}  :body ""}))))
+    (is (= (af {}) {:status 302 :headers {"Location" "cas server fn/login?service=service fn"}  :body ""}))
+    (is (= (af {:headers {"ajax-request" true}}) {:status 403}))))
 
 (def ^:dynamic test-validator (fn [cas-server-fn ticket service] nil))
 


### PR DESCRIPTION
This allows browser-side JavaScript to detect when an AJAX request has
failed due to authentication failure.
